### PR TITLE
Monolog 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 # Define the php versions against we want to test our code
 php:
-- 7.1
 - 7.2
+- 7.3
 
 install:
 - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "monolog/monolog": "^2.0",
     "league/flysystem": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": "^7.1",
-    "monolog/monolog": "^1.23",
+    "monolog/monolog": "^1.23|^2.0",
     "league/flysystem": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": "^7.1",
-    "monolog/monolog": "^1.23|^2.0",
+    "monolog/monolog": "^2.0",
     "league/flysystem": "^1.0"
   },
   "require-dev": {

--- a/src/Handler/FlysystemStreamHandler.php
+++ b/src/Handler/FlysystemStreamHandler.php
@@ -58,7 +58,7 @@ class FlysystemStreamHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         if (is_array($record['formatted'])) {
             $record['formatted'] = json_encode($record['formatted']);


### PR DESCRIPTION
With few line changes is possible to make this nice library be used with new Monolog.

Minimal PHP version was increased due that Monolog 2.0 requirement.